### PR TITLE
Minimum connection pool

### DIFF
--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/linkedin/AsyncClientFactory.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/linkedin/AsyncClientFactory.java
@@ -102,6 +102,7 @@ public class AsyncClientFactory {
             .setIdleEndpointTimeout(Duration.ofHours(1L)) // Default
             .setIdleConnectionTimeout(Duration.ofMinutes(5)) // Custom
             .setMaxConnectionsPerEndpoint(130) // Default
+            .setMinConnectionsPerEndpoint(0) // Default
             .setMaxRequestsPerConnection(30); // Default
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ConnectionPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ConnectionPolicy.java
@@ -41,6 +41,7 @@ public final class ConnectionPolicy {
     private Duration idleTcpConnectionTimeout;
     private Duration idleTcpEndpointTimeout;
     private int maxConnectionsPerEndpoint;
+    private int minConnectionsPerEndpoint;
     private int maxRequestsPerConnection;
     private Duration tcpNetworkRequestTimeout;
     private boolean tcpConnectionEndpointRediscoveryEnabled;
@@ -73,6 +74,7 @@ public final class ConnectionPolicy {
         this.idleTcpConnectionTimeout = directConnectionConfig.getIdleConnectionTimeout();
         this.idleTcpEndpointTimeout = directConnectionConfig.getIdleEndpointTimeout();
         this.maxConnectionsPerEndpoint = directConnectionConfig.getMaxConnectionsPerEndpoint();
+        this.minConnectionsPerEndpoint = directConnectionConfig.getMinConnectionsPerEndpoint();
         this.maxRequestsPerConnection = directConnectionConfig.getMaxRequestsPerConnection();
         this.tcpNetworkRequestTimeout = directConnectionConfig.getNetworkRequestTimeout();
         this.tcpConnectionEndpointRediscoveryEnabled = directConnectionConfig.isConnectionEndpointRediscoveryEnabled();
@@ -535,6 +537,24 @@ public final class ConnectionPolicy {
      */
     public ConnectionPolicy setMaxConnectionsPerEndpoint(int maxConnectionsPerEndpoint) {
         this.maxConnectionsPerEndpoint = maxConnectionsPerEndpoint;
+        return this;
+    }
+
+    /**
+     * Gets the min channels per endpoint
+     * @return the min channels per endpoint
+     */
+    public int getMinConnectionsPerEndpoint() {
+        return minConnectionsPerEndpoint;
+    }
+
+    /**
+     * Sets the min channels per endpoint
+     * @param minConnectionsPerEndpoint the min channels per endpoint
+     * @return the {@link ConnectionPolicy}
+     */
+    public ConnectionPolicy setMinConnectionsPerEndpoint(int minConnectionsPerEndpoint) {
+        this.minConnectionsPerEndpoint = minConnectionsPerEndpoint;
         return this;
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/rntbd/RntbdClientChannelPool.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/rntbd/RntbdClientChannelPool.java
@@ -746,7 +746,12 @@ public final class RntbdClientChannelPool implements ChannelPool {
                     // Fulfill this request with a new channel, assuming we can connect one
                     // If our connection attempt fails, notifyChannelConnect will call us again
 
-                    final Promise<Channel> anotherPromise = this.newChannelPromiseForToBeEstablishedChannel(promise);
+                    // TODO: do we need to create new OpenChannelMinPoolPromise is the current one is of that type?
+                    //  Will it work if we reuse the OpenChannelMinPoolPromise promise we already have? Or should we
+                    //  create newChannelPromiseForToBeEstablishedChannel? Any issues with event loops etc?
+                    final Promise<Channel> anotherPromise = (promise instanceof OpenChannelMinPoolPromise) ?
+                        new OpenChannelMinPoolPromise(promise, promise.getExpiryTimeInNanos(), promise.getRntbdRequestRecord())
+                        : this.newChannelPromiseForToBeEstablishedChannel(promise);
 
                     RntbdChannelAcquisitionTimeline.startNewEvent(
                         channelAcquisitionTimeline,

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/rntbd/RntbdClientChannelPool.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/rntbd/RntbdClientChannelPool.java
@@ -734,7 +734,7 @@ public final class RntbdClientChannelPool implements ChannelPool {
                         // and these will be created one after another - each waiting to open connection - and the
                         // new channels being established will trigger the next pull from the queue of requests. Note
                         // that having more than the min pool size internal channel opening requests is no-op.
-                        for (int i = 1; i < minChannels; i++ ) {
+                        for (int i = 1; i < minChannels; i++) {
                             RntbdRequestRecord opRecord = promise.getRntbdRequestRecord();
                             OpenChannelMinPoolPromise minPoolPromise = new OpenChannelMinPoolPromise(
                                 this.getNewChannelPromise(), this.getNewPromiseExpiryTime(),
@@ -776,6 +776,11 @@ public final class RntbdClientChannelPool implements ChannelPool {
                     return;
                 }
 
+            } else if (promise instanceof OpenChannelMinPoolPromise) {
+                // to be here if the promise is for opening minimum connections, means it already has the number of such
+                // connections required - do nothing more. Such request should never be processed in other ways,
+                // their sole purpose is to obtain channel and release it to the pool - there is no real request inside.
+                return;
             } else if (this.computeLoadFactor() > 0.90D) {
 
                 // All channels are swamped and we'll pick the one with the lowest pending request count

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/rntbd/RntbdClientChannelPool.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/rntbd/RntbdClientChannelPool.java
@@ -735,7 +735,6 @@ public final class RntbdClientChannelPool implements ChannelPool {
                         // new channels being established will trigger the next pull from the queue of requests. Note
                         // that having more than the min pool size internal channel opening requests is no-op.
                         for (int i = 1; i < minChannels; i++) {
-                            RntbdRequestRecord opRecord = promise.getRntbdRequestRecord();
                             OpenChannelMinPoolPromise minPoolPromise = new OpenChannelMinPoolPromise(
                                 this.getNewChannelPromise(), this.getNewPromiseExpiryTime(),
                                 promise.getRntbdRequestRecord());
@@ -765,7 +764,7 @@ public final class RntbdClientChannelPool implements ChannelPool {
                         }
                     }
 
-                    ChannelFuture future = this.bootstrap.clone().attr(POOL_KEY, this).connect();
+                    final ChannelFuture future = this.bootstrap.clone().attr(POOL_KEY, this).connect();
 
                     if (future.isDone()) {
                         this.safeNotifyChannelConnect(future, anotherPromise);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/rntbd/RntbdEndpoint.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/rntbd/RntbdEndpoint.java
@@ -194,6 +194,11 @@ public interface RntbdEndpoint extends AutoCloseable {
         }
 
         @JsonProperty
+        public int minChannelsPerEndpoint() {
+            return this.options.minChannelsPerEndpoint();
+        }
+
+        @JsonProperty
         public int maxRequestsPerChannel() {
             return this.options.maxRequestsPerChannel();
         }


### PR DESCRIPTION
# Motivation

Maintain one or more connection to an endpoint all the time to enable lower latency.

# Configuring minimum connection pool

Add new getter/setter for min connections per endpoint setting to the DirectConnectionConfig and ConnectionPolicy corresponding to existing getter/setters for max connections per endpoint already provided in these configs.

```
setMinConnectionsPerEndpoint(int);
int getMinConnectionsPerEndpoint();
```

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# Implementation detail
- the main change is only in the RntbdClientChannelPool.
- The rest of changes are simply to allow minConnectionsPerEndpoint setting to be configured in the same way and same places where maxConnectionsPerEndpoint can be configured currently plus additional checks to ensure minConnectionsPerEndpoint <= maxConnectionsPerEndpoint when either of the settings is changed.

The main idea is to use dummy, internal only to RntbdClientChannelPool promises that are queued whenever the very first request to open a connection (and only on the first such request - not the normal operational requests) comes in and minConnectionsPerEndpoint > 1. The request to open connections are issued once upon initialization when openConnectionsAndInitCaches is called or when the GlobalAddressCache gets a new endpoint.

The queued dummy requests will be processed as the new connections are opened and released or whenever other requests processed from the queue are done or any other event triggers the polling for the next request from the queue.

When these dummy request are processed, these will be dropped (noop) if the number of channels in the pool is already equal or higher than the minimum number of connections per endpoint setting. If the minimum number or channels is not reached yet, the dummy request will be processed, but with a change - for it a free connection from the pool to use will not be acquired - instead the request will follow the code path to create a new channel.

The opening of these extra connections does not interfere much with initial startup and does not require special background thread/processing relying instead on the normal event loop/executors and still opens new channels in serialized way observing the max and min limits. The opening and releasing to the pool the very first connection will trigger the polling of pending request in the queue and pick the still pending dummy requests and thus these extra connections will be opened one by one.

Why not just call acquire connection multiple times from openConnectionsAndInitCaches? Such requests beside the very first one would be satisfied by already existing channels in the pool and will not create new connections actually. One will need to change a lot of interfaces/signatures to pass down to the pool "please do not re-use connection for this request - open new one instead" in first place and then to implement this in the pool one will need to make similar changes as this PR does in the pool anyway. 

An approach where instead of acquire connections call from call openConnectionsAndInitCaches one sends high number of real read request (number or max requests per channel X min pool size to trigger new connection being opened) simultaneously could be made but will slow down the opening and still may not open too many new channels if existing ones get reused quickly. This will very closely match what forklift does to warm connections.

# All SDK Contribution checklist:
- [ x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x ] Title of the pull request is clear and informative.
- [x ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
